### PR TITLE
chore: add SCA to plugin name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default async function register(app) {
       {
         name: "stripe_payment_intent",
         canRefund: true,
-        displayName: "Stripe",
+        displayName: "Stripe (SCA)",
         functions: {
           capturePayment: stripeCapturePayment,
           createAuthorizedPayment: stripeCreateAuthorizedPayment,


### PR DESCRIPTION
this will help to differentiate in admin from original Stripe plugin